### PR TITLE
remove redundant configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN git clone --depth 1 https://github.com/vim/vim.git \
    --enable-python3interp \
    --enable-perlinterp \
    --enable-luainterp\
-   make VIMRUNTIMEDIR=/usr/share/vim/vim74 && \
    make install \
  && cd .. && rm -rf vim
 


### PR DESCRIPTION
removed `make VIMRUNTIMEDIR=/usr/share/vim/vim74` line cause it's redundant and also outdated -vim81 at the moment