### PR TITLE
remove outdated redundancy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN git clone --depth 1 https://github.com/vim/vim.git \
    --enable-python3interp \
    --enable-perlinterp \
    --enable-luainterp\
-   make VIMRUNTIMEDIR=/usr/share/vim/vim74 && \
-   make install \
+    && make install \
  && cd .. && rm -rf vim
 
 RUN adduser --disabled-password --gecos "" -uid 1001 rat


### PR DESCRIPTION
remove make VIMRUNTIMEDIR=/usr/share/vim/vim74 line cause it's redundant and also outdated -vim81 at the moment